### PR TITLE
Add auto-refresh to keep shared dashboard in sync

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import PastebinWidget from "@/components/PastebinWidget";
 import EventsWidget from "@/components/EventsWidget";
 import WeatherWidget from "@/components/WeatherWidget";
 import ErrorBoundary from "@/components/ErrorBoundary";
+import AutoRefresh from "@/components/AutoRefresh";
 
 export default async function Home() {
   const [tasks, note, links, events] = await Promise.all([
@@ -23,6 +24,7 @@ export default async function Home() {
 
   return (
     <>
+      <AutoRefresh />
       <header className={styles.header}>
         <h1 className={styles.headerTitle}>
           <LayoutDashboard size={32} />

--- a/src/components/AutoRefresh.tsx
+++ b/src/components/AutoRefresh.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+const REFRESH_INTERVAL_MS = 30_000; // 30 seconds
+
+export default function AutoRefresh() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      router.refresh();
+    }, REFRESH_INTERVAL_MS);
+
+    return () => clearInterval(id);
+  }, [router]);
+
+  return null;
+}


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

- Adds an `AutoRefresh` client component that calls `router.refresh()` every 30 seconds
- `router.refresh()` triggers the server component to re-fetch all data (tasks, notes, links, events) without losing client-side state (scroll position, form inputs, etc.)
- Fixes the core gap where `revalidatePath("/")` only invalidates the cache for the user who triggered the action, leaving the other user with stale data

## How it works

The `AutoRefresh` component renders nothing (`return null`) and uses a `useEffect` with `setInterval` to periodically call `router.refresh()`. This causes Next.js to make a new request to the server, re-render the Server Component tree, and merge the updated payload into the client — all without a full page reload.

## Test plan

- [ ] Open dashboard on two devices/tabs
- [ ] Add a task on one device
- [ ] Verify the other device picks up the change within ~30 seconds
- [ ] Verify client-side state (scroll position, open forms) is preserved during refresh

Resolves [IRL-8](https://linear.app/alecv/issue/IRL-8/no-page-auto-refresh-stale-data-after-server-actions)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/us/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
