### PR TITLE
Replace browser confirm() dialogs with styled ConfirmDialog modal

### DIFF
--- a/src/components/ConfirmDialog.module.css
+++ b/src/components/ConfirmDialog.module.css
@@ -1,0 +1,90 @@
+.dialog {
+  border: none;
+  background: transparent;
+  padding: 0;
+  max-width: 100vw;
+  max-height: 100vh;
+  overflow: visible;
+}
+
+.dialog::backdrop {
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.content {
+  background: var(--bg-color-secondary);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  min-width: 280px;
+  max-width: 360px;
+  box-shadow: var(--shadow-md);
+  animation: dialogIn 0.15s ease-out;
+}
+
+@keyframes dialogIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+
+.message {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: var(--spacing-md);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.cancelBtn {
+  background: transparent;
+  border: 1px solid var(--surface-border);
+  color: var(--text-secondary);
+  padding: 8px 16px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.cancelBtn:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.confirmBtn {
+  background: var(--color-error);
+  border: none;
+  color: white;
+  padding: 8px 16px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.confirmBtn:hover {
+  background: #c05555;
+  box-shadow: 0 0 12px rgba(212, 107, 107, 0.3);
+}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import styles from "./ConfirmDialog.module.css";
+
+type ConfirmDialogProps = {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export default function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = "Delete",
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (open && !dialog.open) {
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    function handleClose() {
+      if (open) onCancel();
+    }
+    dialog.addEventListener("close", handleClose);
+    return () => dialog.removeEventListener("close", handleClose);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <dialog ref={dialogRef} className={styles.dialog} onClick={(e) => {
+      if (e.target === dialogRef.current) onCancel();
+    }}>
+      <div className={styles.content}>
+        <h3 className={styles.title}>{title}</h3>
+        <p className={styles.message}>{message}</p>
+        <div className={styles.actions}>
+          <button className={styles.cancelBtn} onClick={onCancel}>
+            Cancel
+          </button>
+          <button className={styles.confirmBtn} onClick={onConfirm}>
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/src/components/EventsWidget.tsx
+++ b/src/components/EventsWidget.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { addEvent, deleteEvent } from "@/app/actions/events";
 import { CalendarDays, CheckSquare2, Plus, Trash2 } from "lucide-react";
+import ConfirmDialog from "./ConfirmDialog";
 import styles from "./EventsWidget.module.css";
 import { taskAssigneeMeta, type TaskAssignee } from "@/lib/tasks";
 
@@ -43,6 +44,7 @@ export default function EventsWidget({
   initialTasks: TaskItem[];
 }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const formRef = useRef<HTMLFormElement>(null);
 
   async function handleAdd(formData: FormData) {
@@ -56,11 +58,12 @@ export default function EventsWidget({
     }
   }
 
-  async function handleDelete(id: string) {
-    if (confirm("Delete this event?")) {
-      await deleteEvent(id);
+  const handleConfirmDelete = useCallback(async () => {
+    if (deleteTarget) {
+      await deleteEvent(deleteTarget);
+      setDeleteTarget(null);
     }
-  }
+  }, [deleteTarget]);
 
   const formatEventDate = (date: Date) => {
     return new Intl.DateTimeFormat("en-US", {
@@ -132,7 +135,7 @@ export default function EventsWidget({
               </span>
             </div>
             {item.kind === "event" ? (
-              <button className={`${styles.deleteBtn} btn-icon`} onClick={() => handleDelete(item.id)}>
+              <button className={`${styles.deleteBtn} btn-icon`} onClick={() => setDeleteTarget(item.id)}>
                 <Trash2 size={14} />
               </button>
             ) : (
@@ -152,6 +155,14 @@ export default function EventsWidget({
           <Plus size={16} />
         </button>
       </form>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Delete event"
+        message="This event will be permanently removed."
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/src/components/PastebinWidget.tsx
+++ b/src/components/PastebinWidget.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { addLink, deleteLink, togglePin } from "@/app/actions/links";
 import { Pin, PinOff, Plus, Trash2 } from "lucide-react";
+import ConfirmDialog from "./ConfirmDialog";
 import styles from "./PastebinWidget.module.css";
 
 type LinkItem = {
@@ -23,6 +24,7 @@ function daysAgo(date: Date): string {
 
 export default function PastebinWidget({ initialLinks }: { initialLinks: LinkItem[] }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const formRef = useRef<HTMLFormElement>(null);
 
   const formatUrl = (u: string) => {
@@ -41,11 +43,12 @@ export default function PastebinWidget({ initialLinks }: { initialLinks: LinkIte
     }
   }
 
-  async function handleDelete(id: string) {
-    if (confirm("Delete this link?")) {
-      await deleteLink(id);
+  const handleConfirmDelete = useCallback(async () => {
+    if (deleteTarget) {
+      await deleteLink(deleteTarget);
+      setDeleteTarget(null);
     }
-  }
+  }, [deleteTarget]);
 
   return (
     <div className={styles.container}>
@@ -76,7 +79,7 @@ export default function PastebinWidget({ initialLinks }: { initialLinks: LinkIte
               >
                 {link.isPinned ? <Pin size={14} /> : <PinOff size={14} />}
               </button>
-              <button className={`${styles.deleteBtn} btn-icon`} onClick={() => handleDelete(link.id)}>
+              <button className={`${styles.deleteBtn} btn-icon`} onClick={() => setDeleteTarget(link.id)}>
                 <Trash2 size={14} />
               </button>
             </div>
@@ -92,6 +95,14 @@ export default function PastebinWidget({ initialLinks }: { initialLinks: LinkIte
           <Plus size={18} />
         </button>
       </form>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Delete link"
+        message="This link will be permanently removed."
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

- Adds a reusable `ConfirmDialog` component using the native HTML `<dialog>` element, styled to match the Herstel warm dark theme with backdrop blur, scale-in animation, and destructive-action red button
- Replaces `confirm("Delete this link?")` in `PastebinWidget` and `confirm("Delete this event?")` in `EventsWidget` with the new styled modal
- Eliminates jarring native browser dialogs that break the design aesthetic, especially on mobile

## Implementation

The `ConfirmDialog` component uses `showModal()` for proper focus trapping and accessibility. It supports:
- Escape key dismissal (native `<dialog>` behavior)
- Backdrop click to cancel
- Customizable title, message, and confirm button label
- CSS module styling consistent with existing widget patterns

## Test plan

- [ ] Click trash icon on a link in the Pastebin widget — styled modal appears
- [ ] Click "Cancel" or press Escape — modal closes, link not deleted
- [ ] Click "Delete" — link is removed
- [ ] Click trash icon on an event in the Events widget — styled modal appears
- [ ] Confirm deletion of an event — event is removed
- [ ] Test on mobile viewport — modal renders correctly without native browser chrome

Closes [IRL-11](https://linear.app/alecv/issue/IRL-11/no-delete-confirmation-ux-uses-browser-confirm-dialogs)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/us/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
