### PR TITLE
Rename assignee enum value WIFE → PAU

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Open `http://localhost:3000`.
 Each task supports:
 
 - `title`
-- `assignee`: `SHARED | ALEC | WIFE`
+- `assignee`: `SHARED | ALEC | PAU`
 - `priority`: `LOW | MEDIUM | HIGH`
 - `bucket`: `TODAY | THIS_WEEK | RECURRING | LATER`
 - `recurrence`: `NONE | DAILY | WEEKLY | MONTHLY`

--- a/prisma/migrations/20260414185202_rename_wife_to_pau/migration.sql
+++ b/prisma/migrations/20260414185202_rename_wife_to_pau/migration.sql
@@ -1,0 +1,2 @@
+-- Rename assignee value WIFE → PAU in all existing task rows
+UPDATE "Task" SET "assignee" = 'PAU' WHERE "assignee" = 'WIFE';

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -1,4 +1,4 @@
-export const taskAssigneeOrder = ["SHARED", "ALEC", "WIFE"] as const;
+export const taskAssigneeOrder = ["SHARED", "ALEC", "PAU"] as const;
 export type TaskAssignee = (typeof taskAssigneeOrder)[number];
 const validAssignees = new Set<TaskAssignee>(taskAssigneeOrder);
 
@@ -31,10 +31,10 @@ export const taskAssigneeMeta: Record<
     avatar: "A",
     accentClass: "alecAccent",
   },
-  WIFE: {
+  PAU: {
     label: "Pau",
     avatar: "P",
-    accentClass: "wifeAccent",
+    accentClass: "pauAccent",
   },
 };
 


### PR DESCRIPTION
Assignee: @alecvdp ([alecvdpoel](https://linear.app/alecv/profiles/alecvdpoel))

## Summary

- Renames the `"WIFE"` assignee enum value to `"PAU"` in `taskAssigneeOrder` and `taskAssigneeMeta`
- Renames the CSS accent class from `wifeAccent` to `pauAccent`
- Adds a data migration (`20260414185202_rename_wife_to_pau`) to update all existing task rows from `WIFE` → `PAU`
- Updates `README.md` to reflect the new enum value

Cosmetic change so the raw data and schema look right if inspected. No functional behavior changes.

Resolves [IRL-9](https://linear.app/alecv/issue/IRL-9/assignee-wife-in-schema-should-use-paus-name)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/us/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
