### PR TITLE
Resolve 4 correctness bugs (IRL-21, 22, 23, 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    # Use a throwaway SQLite file. The build prerenders / which queries the DB,
+    # so we need a real (empty) database — not just a generated Prisma client.
+    env:
+      DATABASE_URL: file:./prisma/ci.db
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply Prisma migrations
+        run: npx prisma migrate deploy
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
         "prisma": "5.22.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -266,21 +267,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -288,9 +289,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1275,6 +1276,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
@@ -1343,10 +1354,318 @@
         "@prisma/debug": "5.22.0"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1369,6 +1688,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2009,6 +2346,119 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2242,6 +2692,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2452,6 +2912,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2657,8 +3127,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2834,6 +3304,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3338,6 +3815,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3346,6 +3833,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4427,6 +4924,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4480,6 +5250,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4817,6 +5597,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4925,6 +5716,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4952,6 +5750,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -5149,6 +5976,40 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
     "node_modules/run-parallel": {
@@ -5452,6 +6313,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5465,6 +6333,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5667,6 +6549,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5713,6 +6612,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6004,6 +6913,200 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6107,6 +7210,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start -H 0.0.0.0",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@prisma/client": "5.22.0",
@@ -23,6 +25,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "prisma": "5.22.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.4"
   }
 }

--- a/src/app/actions/links.ts
+++ b/src/app/actions/links.ts
@@ -2,6 +2,7 @@
 
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import { normalizeExternalUrl } from "@/lib/url";
 
 const EXPIRY_DAYS = 7;
 
@@ -23,11 +24,14 @@ export async function getLinks() {
 }
 
 export async function addLink(formData: FormData) {
-  const url = formData.get("url")?.toString();
-  const title = formData.get("title")?.toString();
+  const rawUrl = formData.get("url")?.toString();
+  const title = formData.get("title")?.toString()?.trim();
   const isPinned = formData.get("isPinned") === "true";
 
-  if (!url || !title) return;
+  if (!rawUrl || !title) return;
+
+  const url = normalizeExternalUrl(rawUrl);
+  if (!url) return;
 
   try {
     await prisma.link.create({

--- a/src/app/actions/tasks.ts
+++ b/src/app/actions/tasks.ts
@@ -3,6 +3,7 @@
 import type { Task as PrismaTask } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import { addCalendarDays, addCalendarMonths, parseCalendarDate } from "@/lib/dates";
 import {
   normalizeTaskAssignee,
   normalizeTaskBucket,
@@ -36,10 +37,7 @@ function parseRecurrence(value: string): TaskRecurrence {
 }
 
 function parseDueDate(value: string | null | undefined) {
-  if (!value) return null;
-
-  const parsed = new Date(`${value}T12:00:00`);
-  return Number.isNaN(parsed.getTime()) ? null : parsed;
+  return parseCalendarDate(value);
 }
 
 function getSectionUpdate(section: TaskSection) {
@@ -51,57 +49,34 @@ function getSectionUpdate(section: TaskSection) {
 }
 
 function addInterval(date: Date, recurrence: TaskRecurrence) {
-  const next = new Date(date);
-
-  if (recurrence === "DAILY") {
-    next.setDate(next.getDate() + 1);
-  } else if (recurrence === "WEEKLY") {
-    next.setDate(next.getDate() + 7);
-  } else if (recurrence === "MONTHLY") {
-    next.setMonth(next.getMonth() + 1);
-  }
-
-  return next;
+  if (recurrence === "DAILY") return addCalendarDays(date, 1);
+  if (recurrence === "WEEKLY") return addCalendarDays(date, 7);
+  if (recurrence === "MONTHLY") return addCalendarMonths(date, 1);
+  return new Date(date);
 }
 
 function subtractInterval(date: Date, recurrence: TaskRecurrence) {
-  const previous = new Date(date);
-
-  if (recurrence === "DAILY") {
-    previous.setDate(previous.getDate() - 1);
-  } else if (recurrence === "WEEKLY") {
-    previous.setDate(previous.getDate() - 7);
-  } else if (recurrence === "MONTHLY") {
-    previous.setMonth(previous.getMonth() - 1);
-  }
-
-  return previous;
+  if (recurrence === "DAILY") return addCalendarDays(date, -1);
+  if (recurrence === "WEEKLY") return addCalendarDays(date, -7);
+  if (recurrence === "MONTHLY") return addCalendarMonths(date, -1);
+  return new Date(date);
 }
 
 async function syncRecurringTasks() {
-  const now = new Date();
-  const recurringTasks = await prisma.task.findMany({
+  // Single atomic write — DB serializes concurrent calls so a recurring task
+  // can't be reset twice when two requests race.
+  await prisma.task.updateMany({
     where: {
       completed: true,
       NOT: { recurrence: "NONE" },
-      nextResetAt: { lte: now },
+      nextResetAt: { lte: new Date() },
+    },
+    data: {
+      completed: false,
+      lastCompletedAt: null,
+      nextResetAt: null,
     },
   });
-
-  if (recurringTasks.length === 0) return;
-
-  await Promise.all(
-    recurringTasks.map((task) =>
-      prisma.task.update({
-        where: { id: task.id },
-        data: {
-          completed: false,
-          lastCompletedAt: null,
-          nextResetAt: null,
-        },
-      })
-    )
-  );
 }
 
 type SharedTask = Omit<PrismaTask, "assignee" | "priority" | "bucket" | "recurrence"> & {

--- a/src/components/EventsWidget.tsx
+++ b/src/components/EventsWidget.tsx
@@ -5,6 +5,7 @@ import { addEvent, deleteEvent } from "@/app/actions/events";
 import { CalendarDays, CheckSquare2, Plus, Trash2 } from "lucide-react";
 import ConfirmDialog from "./ConfirmDialog";
 import styles from "./EventsWidget.module.css";
+import { daysUntilCalendarDate } from "@/lib/dates";
 import { taskAssigneeMeta, type TaskAssignee } from "@/lib/tasks";
 
 type EventItem = {
@@ -86,13 +87,11 @@ export default function EventsWidget({
   };
 
   const getDaysUntil = (date: Date) => {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const eventDate = new Date(date);
-    eventDate.setHours(0, 0, 0, 0);
-    const diffTime = Math.abs(eventDate.getTime() - today.getTime());
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24)); 
-    
+    const diffDays = daysUntilCalendarDate(date);
+    if (diffDays < 0) {
+      const past = Math.abs(diffDays);
+      return past === 1 ? "Yesterday" : `${past} days ago`;
+    }
     if (diffDays === 0) return "Today";
     if (diffDays === 1) return "Tomorrow";
     return `In ${diffDays} days`;

--- a/src/components/PastebinWidget.tsx
+++ b/src/components/PastebinWidget.tsx
@@ -4,6 +4,7 @@ import { useCallback, useRef, useState } from "react";
 import { addLink, deleteLink, togglePin } from "@/app/actions/links";
 import { Pin, PinOff, Plus, Trash2 } from "lucide-react";
 import ConfirmDialog from "./ConfirmDialog";
+import { normalizeExternalUrl } from "@/lib/url";
 import styles from "./PastebinWidget.module.css";
 
 type LinkItem = {
@@ -27,10 +28,10 @@ export default function PastebinWidget({ initialLinks }: { initialLinks: LinkIte
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const formRef = useRef<HTMLFormElement>(null);
 
-  const formatUrl = (u: string) => {
-    if (!u.startsWith("http://") && !u.startsWith("https://")) return `https://${u}`;
-    return u;
-  };
+  // Already-stored URLs went through normalizeExternalUrl on the server, but
+  // anything pre-allowlist may be a bare hostname — re-normalize defensively
+  // and fall back to "#" if the value somehow isn't http/https-shaped.
+  const safeHref = (u: string) => normalizeExternalUrl(u) ?? "#";
 
   async function handleAdd(formData: FormData) {
     if (isSubmitting) return;
@@ -60,7 +61,7 @@ export default function PastebinWidget({ initialLinks }: { initialLinks: LinkIte
         {initialLinks.map(link => (
           <div key={link.id} className={`${styles.linkCard} ${link.isPinned ? styles.pinned : ""}`}>
             <a
-              href={formatUrl(link.url)}
+              href={safeHref(link.url)}
               target="_blank"
               rel="noopener noreferrer"
               className={styles.linkArea}

--- a/src/components/TasksWidget.tsx
+++ b/src/components/TasksWidget.tsx
@@ -18,6 +18,10 @@ import {
 import ConfirmDialog from "./ConfirmDialog";
 import styles from "./TasksWidget.module.css";
 import {
+  daysUntilCalendarDate,
+  formatCalendarDateForInput,
+} from "@/lib/dates";
+import {
   taskAssigneeMeta,
   taskAssigneeOrder,
   taskBucketMeta,
@@ -54,34 +58,17 @@ function getTaskSection(task: Task): TaskSection {
   return task.bucket;
 }
 
-function formatDateForInput(date: Task["dueDate"]) {
-  if (!date) return "";
-  const parsed = new Date(date);
-  const year = parsed.getFullYear();
-  const month = `${parsed.getMonth() + 1}`.padStart(2, "0");
-  const day = `${parsed.getDate()}`.padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
-
 function formatResetLabel(date: Task["nextResetAt"]) {
   if (!date) return null;
-  const resetDate = new Date(date);
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  resetDate.setHours(0, 0, 0, 0);
-  const diffDays = Math.round((resetDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+  const diffDays = daysUntilCalendarDate(date);
   if (diffDays <= 0) return "Resets today";
   if (diffDays === 1) return "Resets tomorrow";
-  return `Resets ${new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" }).format(resetDate)}`;
+  return `Resets ${new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" }).format(new Date(date))}`;
 }
 
 function getDueLabel(date: Task["dueDate"]) {
   if (!date) return null;
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const due = new Date(date);
-  due.setHours(0, 0, 0, 0);
-  const diff = Math.round((due.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+  const diff = daysUntilCalendarDate(date);
   if (diff < 0) return { text: `${Math.abs(diff)}d overdue`, isUrgent: true };
   if (diff === 0) return { text: "today", isUrgent: true };
   if (diff === 1) return { text: "tomorrow", isUrgent: false };
@@ -202,7 +189,7 @@ export default function TasksWidget({ initialTasks }: { initialTasks: Task[] }) 
     setEditingPriority(task.priority);
     setEditingBucket(task.bucket);
     setEditingRecurrence(task.recurrence);
-    setEditingDueDate(formatDateForInput(task.dueDate));
+    setEditingDueDate(formatCalendarDateForInput(task.dueDate));
     setEditingIsGrocery(task.isGrocery);
   }
 
@@ -276,7 +263,7 @@ export default function TasksWidget({ initialTasks }: { initialTasks: Task[] }) 
             onDrop={async (e) => {
               e.preventDefault();
               const taskId = e.dataTransfer.getData("text/task-id");
-              const draggedTask = initialTasks.find((t) => t.id === taskId);
+              const draggedTask = optimisticTasks.find((t) => t.id === taskId);
               if (draggedTask) await handleMove(draggedTask, section);
             }}
           >

--- a/src/lib/dates.test.ts
+++ b/src/lib/dates.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  addCalendarDays,
+  addCalendarMonths,
+  daysUntilCalendarDate,
+  formatCalendarDateForInput,
+  parseCalendarDate,
+} from "./dates";
+
+describe("parseCalendarDate", () => {
+  it("returns null for null/undefined/empty", () => {
+    expect(parseCalendarDate(null)).toBeNull();
+    expect(parseCalendarDate(undefined)).toBeNull();
+    expect(parseCalendarDate("")).toBeNull();
+  });
+
+  it("returns null for malformed input", () => {
+    expect(parseCalendarDate("not-a-date")).toBeNull();
+    expect(parseCalendarDate("2026-13-99")).toBeNull();
+  });
+
+  it("anchors to UTC noon regardless of input", () => {
+    const parsed = parseCalendarDate("2026-04-17");
+    expect(parsed).not.toBeNull();
+    // The whole point of the IRL-22 fix: independent of server TZ, the stored
+    // value is always 12:00:00 UTC on the named day.
+    expect(parsed!.toISOString()).toBe("2026-04-17T12:00:00.000Z");
+  });
+
+  it("preserves the calendar day across DST boundaries", () => {
+    // 2026 US DST starts March 8 at 02:00 local. The day before and the day
+    // after should both round-trip cleanly to UTC noon.
+    expect(parseCalendarDate("2026-03-07")!.toISOString()).toBe(
+      "2026-03-07T12:00:00.000Z",
+    );
+    expect(parseCalendarDate("2026-03-08")!.toISOString()).toBe(
+      "2026-03-08T12:00:00.000Z",
+    );
+    expect(parseCalendarDate("2026-03-09")!.toISOString()).toBe(
+      "2026-03-09T12:00:00.000Z",
+    );
+  });
+});
+
+describe("formatCalendarDateForInput", () => {
+  it("returns empty string for null/undefined", () => {
+    expect(formatCalendarDateForInput(null)).toBe("");
+    expect(formatCalendarDateForInput(undefined)).toBe("");
+  });
+
+  it("round-trips with parseCalendarDate", () => {
+    const cases = ["2026-01-01", "2026-04-17", "2026-12-31", "2027-02-28"];
+    for (const input of cases) {
+      const parsed = parseCalendarDate(input);
+      expect(formatCalendarDateForInput(parsed)).toBe(input);
+    }
+  });
+
+  it("accepts a Date object directly", () => {
+    expect(formatCalendarDateForInput(new Date("2026-04-17T12:00:00.000Z"))).toBe(
+      "2026-04-17",
+    );
+  });
+});
+
+describe("addCalendarDays", () => {
+  it("advances by whole days in UTC", () => {
+    const start = parseCalendarDate("2026-04-17")!;
+    expect(addCalendarDays(start, 1).toISOString()).toBe(
+      "2026-04-18T12:00:00.000Z",
+    );
+    expect(addCalendarDays(start, 7).toISOString()).toBe(
+      "2026-04-24T12:00:00.000Z",
+    );
+    expect(addCalendarDays(start, -1).toISOString()).toBe(
+      "2026-04-16T12:00:00.000Z",
+    );
+  });
+
+  it("does not drift the noon-UTC anchor across DST", () => {
+    // March 7 2026 is the Saturday before US DST starts. Adding 1 day must
+    // still land at noon UTC on March 8, not 11am or 1pm UTC.
+    const before = parseCalendarDate("2026-03-07")!;
+    const after = addCalendarDays(before, 1);
+    expect(after.toISOString()).toBe("2026-03-08T12:00:00.000Z");
+    expect(addCalendarDays(before, 7).toISOString()).toBe(
+      "2026-03-14T12:00:00.000Z",
+    );
+  });
+
+  it("does not mutate the input", () => {
+    const start = parseCalendarDate("2026-04-17")!;
+    const startIso = start.toISOString();
+    addCalendarDays(start, 5);
+    expect(start.toISOString()).toBe(startIso);
+  });
+});
+
+describe("addCalendarMonths", () => {
+  it("advances by whole months in UTC", () => {
+    const start = parseCalendarDate("2026-04-17")!;
+    expect(addCalendarMonths(start, 1).toISOString()).toBe(
+      "2026-05-17T12:00:00.000Z",
+    );
+    expect(addCalendarMonths(start, -1).toISOString()).toBe(
+      "2026-03-17T12:00:00.000Z",
+    );
+  });
+
+  it("handles month-end overflow the same way Date does (Jan 31 + 1mo = Mar 3)", () => {
+    // Documenting current behavior — Date arithmetic rolls over because Feb is
+    // shorter than Jan. If we want clamping ("Jan 31 + 1mo = Feb 28"), that's
+    // a separate decision.
+    const jan31 = parseCalendarDate("2026-01-31")!;
+    const result = addCalendarMonths(jan31, 1);
+    expect(result.toISOString()).toBe("2026-03-03T12:00:00.000Z");
+  });
+});
+
+describe("daysUntilCalendarDate", () => {
+  it("returns 0 for the same calendar day", () => {
+    const now = new Date("2026-04-17T15:00:00");
+    const due = parseCalendarDate("2026-04-17")!;
+    expect(daysUntilCalendarDate(due, now)).toBe(0);
+  });
+
+  it("returns 1 for tomorrow", () => {
+    const now = new Date("2026-04-17T15:00:00");
+    const due = parseCalendarDate("2026-04-18")!;
+    expect(daysUntilCalendarDate(due, now)).toBe(1);
+  });
+
+  it("returns negative for past dates", () => {
+    const now = new Date("2026-04-17T15:00:00");
+    const due = parseCalendarDate("2026-04-15")!;
+    expect(daysUntilCalendarDate(due, now)).toBe(-2);
+  });
+
+  it("rounds across DST so a 1-day diff doesn't collapse to 0", () => {
+    // March 7 → March 8 spans the US DST transition. Naive floor-division of
+    // millisecond diffs would give 0 for the +23h gap. Math.round avoids this.
+    const before = new Date("2026-03-07T15:00:00");
+    const after = parseCalendarDate("2026-03-08")!;
+    expect(daysUntilCalendarDate(after, before)).toBe(1);
+  });
+});

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -53,11 +53,10 @@ export function addCalendarMonths(date: Date, months: number): Date {
 // today" because UTC has rolled over.
 export function daysUntilCalendarDate(date: Date | string, now: Date = new Date()): number {
   const target = typeof date === "string" ? new Date(date) : date;
-  const targetMidnight = new Date(target);
-  targetMidnight.setHours(0, 0, 0, 0);
-  const todayMidnight = new Date(now);
-  todayMidnight.setHours(0, 0, 0, 0);
-  // Math.round, not floor — DST transitions make a "1 day" diff land at 23 or 25
-  // hours, which floor would round down to 0.
-  return Math.round((targetMidnight.getTime() - todayMidnight.getTime()) / DAY_MS);
+  // Extract the calendar day from the UTC-noon anchor so TZ doesn't shift it.
+  const targetDayMs = Date.UTC(target.getUTCFullYear(), target.getUTCMonth(), target.getUTCDate());
+  // "Today" is a viewer/local concept.
+  const todayDayMs = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+  // Math.round handles any sub-day residual from DST boundaries on `now`.
+  return Math.round((targetDayMs - todayDayMs) / DAY_MS);
 }

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,0 +1,63 @@
+// Shared helpers for "calendar dates" — values that represent a day on the
+// calendar (e.g. a task due date, a recurrence anchor) rather than a specific
+// instant in time. Stored as a Date pinned to UTC noon so:
+//
+//   - the value is unambiguous regardless of server timezone (parseDueDate used
+//     to parse strings as local time, which silently shifted dates depending
+//     on whether the server ran in PT or UTC), and
+//
+//   - any reader in any timezone from UTC-12 to UTC+12 sees the same calendar
+//     day when reading with local Date accessors (noon UTC ± 12h stays inside
+//     the same day).
+
+const DAY_MS = 86_400_000;
+
+export function parseCalendarDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  // Force UTC noon — without the trailing Z, JS interprets the string as local
+  // time and the stored value depends on server TZ.
+  const parsed = new Date(`${value}T12:00:00.000Z`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function formatCalendarDateForInput(date: Date | string | null | undefined): string {
+  if (!date) return "";
+  const parsed = typeof date === "string" ? new Date(date) : date;
+  if (Number.isNaN(parsed.getTime())) return "";
+  // Read components in local time. Because calendar dates are pinned to UTC
+  // noon, any TZ between UTC-12 and UTC+12 reads back the same calendar day.
+  const y = parsed.getFullYear();
+  const m = `${parsed.getMonth() + 1}`.padStart(2, "0");
+  const d = `${parsed.getDate()}`.padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+// Day-shifted in UTC so DST transitions don't drift the stored noon-UTC anchor.
+export function addCalendarDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+export function addCalendarMonths(date: Date, months: number): Date {
+  const next = new Date(date);
+  next.setUTCMonth(next.getUTCMonth() + months);
+  return next;
+}
+
+// Days from "today" (in the viewer's local TZ) to the given calendar date.
+// Negative = past, 0 = today, 1 = tomorrow, etc.
+//
+// We compare in *local* time because "today" is a viewer concept — a user in PT
+// at 11pm on April 16 should see "due tomorrow" for an April 17 task, not "due
+// today" because UTC has rolled over.
+export function daysUntilCalendarDate(date: Date | string, now: Date = new Date()): number {
+  const target = typeof date === "string" ? new Date(date) : date;
+  const targetMidnight = new Date(target);
+  targetMidnight.setHours(0, 0, 0, 0);
+  const todayMidnight = new Date(now);
+  todayMidnight.setHours(0, 0, 0, 0);
+  // Math.round, not floor — DST transitions make a "1 day" diff land at 23 or 25
+  // hours, which floor would round down to 0.
+  return Math.round((targetMidnight.getTime() - todayMidnight.getTime()) / DAY_MS);
+}

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -26,9 +26,9 @@ export function formatCalendarDateForInput(date: Date | string | null | undefine
   if (Number.isNaN(parsed.getTime())) return "";
   // Read components in local time. Because calendar dates are pinned to UTC
   // noon, any TZ between UTC-12 and UTC+12 reads back the same calendar day.
-  const y = parsed.getFullYear();
-  const m = `${parsed.getMonth() + 1}`.padStart(2, "0");
-  const d = `${parsed.getDate()}`.padStart(2, "0");
+  const y = parsed.getUTCFullYear();
+  const m = `${parsed.getUTCMonth() + 1}`.padStart(2, "0");
+  const d = `${parsed.getUTCDate()}`.padStart(2, "0");
   return `${y}-${m}-${d}`;
 }
 

--- a/src/lib/tasks.test.ts
+++ b/src/lib/tasks.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeTaskAssignee,
+  normalizeTaskBucket,
+  normalizeTaskPriority,
+  normalizeTaskRecurrence,
+} from "./tasks";
+
+describe("normalizeTaskAssignee", () => {
+  it("passes through valid values", () => {
+    expect(normalizeTaskAssignee("SHARED")).toBe("SHARED");
+    expect(normalizeTaskAssignee("ALEC")).toBe("ALEC");
+    expect(normalizeTaskAssignee("PAU")).toBe("PAU");
+  });
+
+  it("falls back to SHARED for unknown / legacy values", () => {
+    // "WIFE" was the old enum value before IRL-9 renamed to PAU. Rows
+    // migrated incorrectly should not crash — they should just default.
+    expect(normalizeTaskAssignee("WIFE")).toBe("SHARED");
+    expect(normalizeTaskAssignee("")).toBe("SHARED");
+    expect(normalizeTaskAssignee("garbage")).toBe("SHARED");
+  });
+});
+
+describe("normalizeTaskPriority", () => {
+  it("passes through valid values", () => {
+    expect(normalizeTaskPriority("LOW")).toBe("LOW");
+    expect(normalizeTaskPriority("MEDIUM")).toBe("MEDIUM");
+    expect(normalizeTaskPriority("HIGH")).toBe("HIGH");
+  });
+
+  it("falls back to MEDIUM for unknown values", () => {
+    expect(normalizeTaskPriority("URGENT")).toBe("MEDIUM");
+    expect(normalizeTaskPriority("")).toBe("MEDIUM");
+  });
+});
+
+describe("normalizeTaskBucket", () => {
+  it("passes through valid values", () => {
+    expect(normalizeTaskBucket("TODAY")).toBe("TODAY");
+    expect(normalizeTaskBucket("THIS_WEEK")).toBe("THIS_WEEK");
+    expect(normalizeTaskBucket("RECURRING")).toBe("RECURRING");
+    expect(normalizeTaskBucket("LATER")).toBe("LATER");
+  });
+
+  it("falls back to THIS_WEEK for unknown values", () => {
+    expect(normalizeTaskBucket("INBOX")).toBe("THIS_WEEK");
+    expect(normalizeTaskBucket("")).toBe("THIS_WEEK");
+  });
+});
+
+describe("normalizeTaskRecurrence", () => {
+  it("passes through valid values", () => {
+    expect(normalizeTaskRecurrence("NONE")).toBe("NONE");
+    expect(normalizeTaskRecurrence("DAILY")).toBe("DAILY");
+    expect(normalizeTaskRecurrence("WEEKLY")).toBe("WEEKLY");
+    expect(normalizeTaskRecurrence("MONTHLY")).toBe("MONTHLY");
+  });
+
+  it("falls back to NONE for unknown values", () => {
+    expect(normalizeTaskRecurrence("YEARLY")).toBe("NONE");
+    expect(normalizeTaskRecurrence("")).toBe("NONE");
+  });
+});

--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { normalizeExternalUrl } from "./url";
+
+describe("normalizeExternalUrl", () => {
+  it("returns null for empty / whitespace-only input", () => {
+    expect(normalizeExternalUrl("")).toBeNull();
+    expect(normalizeExternalUrl("   ")).toBeNull();
+  });
+
+  it("prepends https:// to a bare hostname", () => {
+    expect(normalizeExternalUrl("example.com")).toBe("https://example.com/");
+    expect(normalizeExternalUrl("example.com/path")).toBe(
+      "https://example.com/path",
+    );
+  });
+
+  it("preserves http:// and https:// URLs", () => {
+    expect(normalizeExternalUrl("http://example.com")).toBe(
+      "http://example.com/",
+    );
+    expect(normalizeExternalUrl("https://example.com/path?q=1")).toBe(
+      "https://example.com/path?q=1",
+    );
+  });
+
+  it("rejects javascript: URIs (the canonical XSS vector for href)", () => {
+    expect(normalizeExternalUrl("javascript:alert(1)")).toBeNull();
+    expect(normalizeExternalUrl("JAVASCRIPT:alert(1)")).toBeNull();
+    expect(normalizeExternalUrl("  javascript:alert(1)  ")).toBeNull();
+  });
+
+  it("rejects data: URIs", () => {
+    expect(
+      normalizeExternalUrl("data:text/html,<script>alert(1)</script>"),
+    ).toBeNull();
+  });
+
+  it("rejects other non-http schemes", () => {
+    expect(normalizeExternalUrl("file:///etc/passwd")).toBeNull();
+    expect(normalizeExternalUrl("vbscript:msgbox(1)")).toBeNull();
+    expect(normalizeExternalUrl("ftp://example.com")).toBeNull();
+    expect(normalizeExternalUrl("mailto:test@example.com")).toBeNull();
+  });
+
+  it("rejects unparseable input", () => {
+    expect(normalizeExternalUrl("http://")).toBeNull();
+  });
+});

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -11,7 +11,7 @@ export function normalizeExternalUrl(input: string): string | null {
   // Default to https:// when the user typed a bare hostname like "example.com".
   // Any other scheme (including javascript:, data:, etc.) gets parsed as-is and
   // then rejected unless it's http or https.
-  const candidate = /^[a-z][a-z0-9+.-]*:/i.test(trimmed)
+  const candidate = /^[a-z][a-z0-9+-]*:/i.test(trimmed)
     ? trimmed
     : `https://${trimmed}`;
 

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,27 @@
+// Normalize and validate user-supplied URLs before storing or rendering them
+// as <a href>. Returns null for anything that isn't a real http/https URL —
+// in particular, javascript:, data:, vbscript:, and file: URIs are rejected.
+
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+export function normalizeExternalUrl(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // Default to https:// when the user typed a bare hostname like "example.com".
+  // Any other scheme (including javascript:, data:, etc.) gets parsed as-is and
+  // then rejected unless it's http or https.
+  const candidate = /^[a-z][a-z0-9+.-]*:/i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return null;
+  }
+
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) return null;
+  return parsed.toString();
+}


### PR DESCRIPTION
## Summary

Bundles fixes for four correctness bugs filed in this morning's review:

- **[IRL-23](https://linear.app/alecv/issue/IRL-23)** — Drag-and-drop in `TasksWidget` was reading from `initialTasks` (server-rendered prop) rather than `optimisticTasks`. With more optimistic updates landing over time, this would silently clobber unsaved state.
- **[IRL-21](https://linear.app/alecv/issue/IRL-21)** — `syncRecurringTasks()` was a `findMany` + `Promise.all(update)` with no concurrency guard. Two simultaneous page loads could both decide a task was due and reset it twice. Now a single atomic `updateMany`.
- **[IRL-22](https://linear.app/alecv/issue/IRL-22)** — Date handling was inconsistent: server parsed `YYYY-MM-DD` as local time (depended on whether the server ran in PT vs UTC); client compared in browser-local TZ. Now: calendar dates are always stored as UTC noon (unambiguous, readable as same calendar day in any TZ from UTC-12 to UTC+12), recurrence math uses `setUTCDate` so DST doesn't drift the anchor, and the diff helper is shared. Bonus: `EventsWidget.getDaysUntil` was using `Math.abs` and labeling overdue items as "In N days" — now correctly says "Yesterday" / "N days ago".
- **[IRL-24](https://linear.app/alecv/issue/IRL-24)** — Pastebin accepted any URL-shaped string as `<a href>`, including `data:`, `javascript:`, `file:`. Now an http/https allowlist enforced both server-side (rejected at the boundary) and defensively in the renderer.

Two new shared helpers: `src/lib/dates.ts` and `src/lib/url.ts`. Net –34 lines after deduping.

## Test plan

- [ ] `npm run lint` — clean
- [ ] `npm run build` — green
- [ ] Manually create a recurring task, complete it, advance time past `nextResetAt`, refresh — task reopens once and stays reopened
- [ ] Create a task with a due date near midnight local TZ — label says "today" / "tomorrow" as expected
- [ ] Drag a task between buckets — the move sticks and doesn't revert any in-flight optimistic edit
- [ ] Try pasting `javascript:alert(1)` into Pastebin — link is rejected (no DB row)
- [ ] Existing pastebin links continue to render and click through correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alecvdp/us/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
